### PR TITLE
Switched from collections to collections.abc

### DIFF
--- a/tools/pyparsing.py
+++ b/tools/pyparsing.py
@@ -68,7 +68,7 @@ import sys
 import warnings
 import re
 import sre_constants
-import collections
+import collections.abc as collections
 import pprint
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )
 


### PR DESCRIPTION
Fixed tools/pyparsing.py which fixes the external interface when using python3.10 and newer

## Description
The abstract base classes in the `collections` module are deprecated since python 3.3 and do not work anymore since python 3.10

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Compiled eT with this version of pcmsolver using python 3.10 and python 3.8 and all tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)

## Status
<!--- Check this box when ready to be merged -->
- [x ] Ready to go
